### PR TITLE
Pokedex Page Styling Improvements

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,4 @@
 @use "@angular/material" as mat;
-@use "sass:map";
 
 .header {
   @include mat.toolbar-overrides(

--- a/src/app/core/enums/theme.enum.ts
+++ b/src/app/core/enums/theme.enum.ts
@@ -1,4 +1,5 @@
 export enum Theme {
+  AUTO = "auto",
   LIGHT = "light",
   LIGHT_CONTRAST = "light-contrast",
   DARK = "dark",

--- a/src/app/core/store/theme.store.ts
+++ b/src/app/core/store/theme.store.ts
@@ -30,12 +30,23 @@ export const ThemeStore = signalStore(
       const newTheme = store.isDarkTheme() ? Theme.LIGHT : Theme.DARK;
       patchState(store, { theme: newTheme });
       document.body.setAttribute("data-theme", newTheme);
+      localStorage.setItem("theme", newTheme);
     },
   })),
   withHooks({
     onInit(store) {
-      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-        store.toggleTheme();
+      const storedTheme = localStorage.getItem("theme") as Theme | null;
+      if (storedTheme) {
+        patchState(store, { theme: storedTheme });
+        document.body.setAttribute("data-theme", storedTheme);
+      } else {
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          patchState(store, { theme: Theme.DARK });
+          document.body.setAttribute("data-theme", Theme.DARK);
+        } else {
+          patchState(store, { theme: Theme.LIGHT });
+          document.body.setAttribute("data-theme", Theme.LIGHT);
+        }
       }
     },
   })

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
@@ -6,6 +6,7 @@
   </div>
   <mat-paginator
     (page)="pokedexEntriesStore.loadPokemonSpecies($event)"
+    [hidePageSize]="hidePageSize()"
     [length]="pokedexEntriesStore.pageEvent().length"
     [pageIndex]="pokedexEntriesStore.pageEvent().pageIndex"
     [pageSizeOptions]="[25, 50, 100]"

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
@@ -1,18 +1,23 @@
-<div class="pokedex-entries-container">
-  <div class="pokedex-entries">
-    @for (entry of pokedexEntriesStore.paginatedPokemonEntries(); track $index) {
-      <pokedex-entry class="entry" [pokemon]="pokedexEntriesStore.entities()[$index]"></pokedex-entry>
-    }
+@if (!(pokedexEntriesStore.paginatedPokemonEntries().length > 0)) {
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+} @else {
+  <div class="pokedex-entries-container">
+    <div class="pokedex-entries">
+      @for (entry of pokedexEntriesStore.paginatedPokemonEntries(); track $index) {
+        <pokedex-entry class="entry" [pokemon]="pokedexEntriesStore.entities()[$index]"></pokedex-entry>
+      }
+    </div>
+    <mat-paginator
+      (page)="pokedexEntriesStore.loadPokemonSpecies($event)"
+      [hidePageSize]="hidePageSize()"
+      [length]="pokedexEntriesStore.pageEvent().length"
+      [pageIndex]="pokedexEntriesStore.pageEvent().pageIndex"
+      [pageSizeOptions]="[25, 50, 100]"
+      [pageSize]="pokedexEntriesStore.pageEvent().pageSize"
+      [showFirstLastButtons]="true"
+      aria-label="Select page"
+    >
+    </mat-paginator>
   </div>
-  <mat-paginator
-    (page)="pokedexEntriesStore.loadPokemonSpecies($event)"
-    [hidePageSize]="hidePageSize()"
-    [length]="pokedexEntriesStore.pageEvent().length"
-    [pageIndex]="pokedexEntriesStore.pageEvent().pageIndex"
-    [pageSizeOptions]="[25, 50, 100]"
-    [pageSize]="pokedexEntriesStore.pageEvent().pageSize"
-    [showFirstLastButtons]="true"
-    aria-label="Select page"
-  >
-  </mat-paginator>
-</div>
+
+}

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.html
@@ -1,15 +1,17 @@
-<div class="pokedex-entries">
-  @for (entry of pokedexEntriesStore.paginatedPokemonEntries(); track $index) {
-    <pokedex-entry class="entry" [pokemon]="pokedexEntriesStore.entities()[$index]"></pokedex-entry>
-  }
+<div class="pokedex-entries-container">
+  <div class="pokedex-entries">
+    @for (entry of pokedexEntriesStore.paginatedPokemonEntries(); track $index) {
+      <pokedex-entry class="entry" [pokemon]="pokedexEntriesStore.entities()[$index]"></pokedex-entry>
+    }
+  </div>
+  <mat-paginator
+    (page)="pokedexEntriesStore.loadPokemonSpecies($event)"
+    [length]="pokedexEntriesStore.pageEvent().length"
+    [pageIndex]="pokedexEntriesStore.pageEvent().pageIndex"
+    [pageSizeOptions]="[25, 50, 100]"
+    [pageSize]="pokedexEntriesStore.pageEvent().pageSize"
+    [showFirstLastButtons]="true"
+    aria-label="Select page"
+  >
+  </mat-paginator>
 </div>
-<mat-paginator
-  (page)="pokedexEntriesStore.loadPokemonSpecies($event)"
-  [length]="pokedexEntriesStore.pageEvent().length"
-  [pageIndex]="pokedexEntriesStore.pageEvent().pageIndex"
-  [pageSizeOptions]="[25, 50, 100]"
-  [pageSize]="pokedexEntriesStore.pageEvent().pageSize"
-  [showFirstLastButtons]="true"
-  aria-label="Select page"
->
-</mat-paginator>

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
@@ -12,10 +12,13 @@
     display: flex;
     justify-content: center;
     align-items: start;
+    align-content: start;
     flex-wrap: wrap;
+    height: 100%;
     gap: 10px;
     overflow-y: scroll;
-    padding: 12px;
+    padding: 10px;
+    background-color: var(--mat-sys-surface-container-low);
 
     .entry {
       height: 200px;

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
@@ -3,9 +3,9 @@
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
-  height: calc(100vh - var(--mat-toolbar-standard-height, 64px) - 57px - var(--mdc-secondary-navigation-tab-container-height, 48px));
+  height: calc(100vh - var(--mat-toolbar-standard-height, 64px) - 50px - var(--mdc-secondary-navigation-tab-container-height, 48px));
   @media (max-width: 599px) {
-    height: calc(100vh - var(--mat-toolbar-mobile-height, 56px) - 57px - var(--mdc-secondary-navigation-tab-container-height, 48px));
+    height: calc(100vh - var(--mat-toolbar-mobile-height, 56px) - 50px - var(--mdc-secondary-navigation-tab-container-height, 48px));
   }
 
   .pokedex-entries {

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.scss
@@ -1,13 +1,29 @@
-.pokedex-entries {
+.pokedex-entries-container {
   display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  overflow-y: scroll;
-  padding: 12px;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  height: calc(100vh - var(--mat-toolbar-standard-height, 64px) - 57px - var(--mdc-secondary-navigation-tab-container-height, 48px));
+  @media (max-width: 599px) {
+    height: calc(100vh - var(--mat-toolbar-mobile-height, 56px) - 57px - var(--mdc-secondary-navigation-tab-container-height, 48px));
+  }
 
-  .entry {
-    height: 200px;
-    width: 160px;
+  .pokedex-entries {
+    display: flex;
+    justify-content: center;
+    align-items: start;
+    flex-wrap: wrap;
+    gap: 10px;
+    overflow-y: scroll;
+    padding: 12px;
+
+    .entry {
+      height: 200px;
+      width: 160px;
+    }
+
+    mat-paginator {
+      flex-shrink: 0;
+    }
   }
 }

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.ts
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.ts
@@ -11,10 +11,11 @@ import { PokedexEntriesStore } from "../../store/pokedex-entries.store";
 import { PokedexEntryComponent } from "./pokedex-entry/pokedex-entry.component";
 import { MatPaginatorModule } from "@angular/material/paginator";
 import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
 
 @Component({
   selector: "pokedex-entries",
-  imports: [PokedexEntryComponent, MatPaginatorModule],
+  imports: [PokedexEntryComponent, MatPaginatorModule, MatProgressBarModule],
   templateUrl: "pokedex-entries.component.html",
   styleUrls: ["pokedex-entries.component.scss"],
   providers: [PokedexEntriesStore],

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.ts
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entries.component.ts
@@ -1,8 +1,16 @@
-import { Component, effect, inject, input } from "@angular/core";
+import {
+  Component,
+  effect,
+  inject,
+  input,
+  OnInit,
+  signal,
+} from "@angular/core";
 import { GameService } from "../../../../shared/services/game.service";
 import { PokedexEntriesStore } from "../../store/pokedex-entries.store";
 import { PokedexEntryComponent } from "./pokedex-entry/pokedex-entry.component";
 import { MatPaginatorModule } from "@angular/material/paginator";
+import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
 
 @Component({
   selector: "pokedex-entries",
@@ -11,10 +19,12 @@ import { MatPaginatorModule } from "@angular/material/paginator";
   styleUrls: ["pokedex-entries.component.scss"],
   providers: [PokedexEntriesStore],
 })
-export class PokedexEntriesComponent {
+export class PokedexEntriesComponent implements OnInit {
+  hidePageSize = signal(true);
   readonly pokedexName = input("");
   readonly gameService = inject(GameService);
   readonly pokedexEntriesStore = inject(PokedexEntriesStore);
+  readonly breakpointObserver = inject(BreakpointObserver);
 
   constructor() {
     effect(() => {
@@ -27,5 +37,17 @@ export class PokedexEntriesComponent {
           });
       }
     });
+  }
+
+  ngOnInit() {
+    this.breakpointObserver
+      .observe([Breakpoints.HandsetPortrait])
+      .subscribe((result) => {
+        if (result.matches) {
+          this.hidePageSize.set(true);
+        } else {
+          this.hidePageSize.set(false);
+        }
+      });
   }
 }

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entry/pokedex-entry.component.html
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entry/pokedex-entry.component.html
@@ -1,8 +1,8 @@
 <mat-card appearance="outlined">
   <mat-card-header>
     <mat-card-title>
-      @if (pokemon?.names) {
-        {{ pokemon!.names | localise : "en" : "name" }}
+      @if (pokemon()?.names && pokemon()!.names.length > 0) {
+        {{ pokemon()!.names | localise : "en" : "name" }}
       } @else {
         <span class="skeleton skeleton-text"></span>
       }
@@ -10,16 +10,16 @@
   </mat-card-header>
   <mat-card-content>
     <div class="image-container">
-      @if (pokemon?.name && pokemon?.names) {
+      @if (pokemon()?.name && pokemon()?.names) {
         <img
           (load)="onImageLoad()"
           [hidden]="imageLoading()"
           [src]="
           'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/' +
-          pokemon?.id +
+          pokemon()?.id +
           '.png'
         "
-          alt="{{ pokemon!.names | localise : 'en' : 'name' }}"
+          alt="{{ pokemon()?.name }}"
           height="90"
           mat-card-image
           width="90"
@@ -33,8 +33,8 @@
     </div>
   </mat-card-content>
   <mat-card-actions [align]="'end'">
-    @if (pokemon?.name) {
-      <a [routerLink]="'/pokemon/' + pokemon!.name" mat-button>View</a>
+    @if (pokemon()?.name) {
+      <a [routerLink]="'/pokemon/' + pokemon()!.name" mat-button>View</a>
     } @else {
       <span class="skeleton skeleton-text"></span>
     }

--- a/src/app/features/pokedex/components/pokedex-entries/pokedex-entry/pokedex-entry.component.ts
+++ b/src/app/features/pokedex/components/pokedex-entries/pokedex-entry/pokedex-entry.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, signal, WritableSignal } from "@angular/core";
+import { Component, input, signal, WritableSignal } from "@angular/core";
 import { MatCardModule } from "@angular/material/card";
 import { MatButtonModule } from "@angular/material/button";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
@@ -19,7 +19,7 @@ import { LocalisePipe } from "../../../../../shared/pipes/localise.pipe";
   styleUrl: "pokedex-entry.component.scss",
 })
 export class PokedexEntryComponent {
-  @Input() pokemon?: PokemonSpecies;
+  pokemon = input<PokemonSpecies>();
   imageLoading: WritableSignal<boolean> = signal(true);
 
   onImageLoad() {

--- a/src/app/features/pokedex/components/version-group-select/version-group-select.component.html
+++ b/src/app/features/pokedex/components/version-group-select/version-group-select.component.html
@@ -4,7 +4,7 @@
     (selectionChange)="navigateToVersionGroupPokedex($event.value)"
     [value]="selectedVersionGroupName()"
   >
-    @for (versionGroup of versionGroupStore.sortedByMostRecent(); track
+    @for (versionGroup of versionGroupStore.entities(); track
       versionGroup.id) {
       <mat-option value="{{ versionGroup.name }}">
         {{ versionGroup.formattedName }}

--- a/src/app/features/pokedex/components/version-group-select/version-group-select.component.html
+++ b/src/app/features/pokedex/components/version-group-select/version-group-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field subscriptSizing="dynamic">
+<mat-form-field class="version-group-select" subscriptSizing="dynamic">
   <mat-label>Pokédex</mat-label>
   <mat-select
     (selectionChange)="navigateToVersionGroupPokedex($event.value)"

--- a/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
+++ b/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
@@ -1,6 +1,11 @@
-mat-form-field {
+@use "@angular/material" as mat;
+
+.version-group-select {
   width: 300px;
   @media (max-width: 599px) {
     width: 100vw;
   }
+  @include mat.form-field-overrides((
+          filled-container-color: var(--mat-sys-secondary-container),
+  ));
 }

--- a/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
+++ b/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
@@ -1,3 +1,6 @@
 mat-form-field {
   width: 300px;
+  @media (max-width: 599px) {
+    width: 100vw;
+  }
 }

--- a/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
+++ b/src/app/features/pokedex/components/version-group-select/version-group-select.component.scss
@@ -7,5 +7,11 @@
   }
   @include mat.form-field-overrides((
           filled-container-color: var(--mat-sys-secondary-container),
+          filled-with-label-container-padding-top: 20px,
+          filled-with-label-container-padding-bottom: 0px,
+          container-height: 48px,
+  ));
+  @include mat.select-overrides((
+          trigger-text-size: var(--mat-sys-title-small),
   ));
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.html
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.html
@@ -13,4 +13,6 @@
       }
     </mat-tab-group>
   </div>
+} @else {
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.html
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.html
@@ -1,18 +1,14 @@
 @if (versionGroupStore.selectedEntity()) {
   <div class="pokedex">
-    <div>
-      <div class="pokedex-options">
-        <version-group-select></version-group-select>
-      </div>
-      <mat-tab-group animationDuration="0ms">
-        @for (pokedex of versionGroupStore.selectedEntity()?.pokedexes; track pokedex.name) {
-          <mat-tab [label]="pokedex.formattedName">
-            <ng-template matTabContent>
-              <pokedex-entries [pokedexName]="pokedex.name"></pokedex-entries>
-            </ng-template>
-          </mat-tab>
-        }
-      </mat-tab-group>
-    </div>
+    <version-group-select></version-group-select>
+    <mat-tab-group animationDuration="0ms">
+      @for (pokedex of versionGroupStore.selectedEntity()?.pokedexes; track pokedex.name) {
+        <mat-tab [label]="pokedex.formattedName">
+          <ng-template matTabContent>
+            <pokedex-entries [pokedexName]="pokedex.name"></pokedex-entries>
+          </ng-template>
+        </mat-tab>
+      }
+    </mat-tab-group>
   </div>
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.html
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.html
@@ -1,6 +1,8 @@
 @if (versionGroupStore.selectedEntity()) {
   <div class="pokedex">
-    <version-group-select></version-group-select>
+    <div class="pokedex-options">
+      <version-group-select></version-group-select>
+    </div>
     <mat-tab-group animationDuration="0ms">
       @for (pokedex of versionGroupStore.selectedEntity()?.pokedexes; track pokedex.name) {
         <mat-tab [label]="pokedex.formattedName">

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
@@ -5,4 +5,8 @@
   @media (max-width: 599px) {
     height: calc(100vh - var(--mat-toolbar-mobile-height, 56px));
   }
+
+  .pokedex-options {
+    background-color: var(--mat-sys-surface-variant)
+  }
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
@@ -1,17 +1,8 @@
 .pokedex {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  height: calc(100vh - 64px);
-
-  .pokedex-options {
-    display: flex;
-    width: 100%;
-    justify-content: space-between;
-    border-bottom: 1px solid var(--mat-sys-outline-variant);
-  }
-
-  mat-paginator {
-    flex-shrink: 0;
+  height: calc(100vh - var(--mat-toolbar-standard-height, 64px));
+  @media (max-width: 599px) {
+    height: calc(100vh - var(--mat-toolbar-mobile-height, 56px));
   }
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.scss
@@ -7,6 +7,6 @@
   }
 
   .pokedex-options {
-    background-color: var(--mat-sys-surface-variant)
+    background-color: var(--mat-sys-secondary-container)
   }
 }

--- a/src/app/features/pokedex/pages/pokedex/pokedex.component.ts
+++ b/src/app/features/pokedex/pages/pokedex/pokedex.component.ts
@@ -5,12 +5,14 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { VersionGroupSelectComponent } from "../../components/version-group-select/version-group-select.component";
 import { PokedexEntriesComponent } from "../../components/pokedex-entries/pokedex-entries.component";
 import { VersionGroupStore } from "../../../../shared/store/version-group.store";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
 
 @Component({
   imports: [
     MatTabsModule,
     VersionGroupSelectComponent,
     PokedexEntriesComponent,
+    MatProgressBarModule,
   ],
   selector: "app-pokedex",
   templateUrl: "pokedex.component.html",

--- a/src/app/features/pokedex/store/pokedex-entries.store.ts
+++ b/src/app/features/pokedex/store/pokedex-entries.store.ts
@@ -67,7 +67,7 @@ export const PokedexEntriesStore = signalStore(
           patchState(store, {
             pageEvent: {
               pageIndex: pageEvent?.pageIndex ? pageEvent.pageIndex : 0,
-              pageSize: pageEvent?.pageSize ? pageEvent.pageSize : 25,
+              pageSize: pageEvent?.pageSize ? pageEvent.pageSize : 50,
               length: store.pokedexEntries().length,
             },
           });

--- a/src/app/shared/store/features/pagination.feature.ts
+++ b/src/app/shared/store/features/pagination.feature.ts
@@ -8,7 +8,7 @@ import {
 } from "@ngrx/signals";
 
 const initialState = signalState<{ pageEvent: PageEvent }>({
-  pageEvent: { pageSize: 25, pageIndex: 0, length: 0 },
+  pageEvent: { pageSize: 50, pageIndex: 0, length: 0 },
 });
 
 export function withPagination() {

--- a/src/app/shared/store/version-group.store.ts
+++ b/src/app/shared/store/version-group.store.ts
@@ -1,25 +1,13 @@
-import {
-  patchState,
-  signalStore,
-  withComputed,
-  withHooks,
-  withMethods,
-} from "@ngrx/signals";
+import { patchState, signalStore, withHooks, withMethods } from "@ngrx/signals";
 import { setAllEntities, withEntities } from "@ngrx/signals/entities";
 import { withSelectedEntity } from "./features/selected-entity.feature";
 import { VersionGroups } from "./data/version-group.constants";
-import { computed } from "@angular/core";
 import { StoredVersionGroup } from "../../core/interfaces/stored-version-group.interface";
 
 export const VersionGroupStore = signalStore(
   { providedIn: "root" },
   withEntities<StoredVersionGroup>(),
   withSelectedEntity(),
-  withComputed((store) => ({
-    sortedByMostRecent: computed(() => {
-      return [...store.entities()].sort((a, b) => b.id - a.id);
-    }),
-  })),
   withMethods((store) => ({
     setSelectedVersionGroupByName(name: string): void {
       const versionGroup = store

--- a/src/styles/_skeletons.scss
+++ b/src/styles/_skeletons.scss
@@ -1,6 +1,12 @@
 .skeleton {
   display: inline-block;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.1) 25%, rgba(255, 255, 255, 0.3) 50%, rgba(255, 255, 255, 0.1) 75%);
+  background: linear-gradient(
+                  -90deg,
+                  var(--primary-color-opacity-10, rgba(240, 240, 240, 0.1)) 0%,
+                  var(--primary-color-opacity-20, rgba(210, 210, 210, 0.2)) 50%,
+                  var(--primary-color-opacity-10, rgba(240, 240, 240, 0.1)) 100%
+  );
+
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite linear;
   border-radius: 4px;


### PR DESCRIPTION
- Pokedex Entries Store now loads Pokemon sequentially rather than all at once to improve performance
- Greater use of Angular Material variables and overrides for colouring
- Pagination bar will always appear at bottom of page
- Theme preference is now saved in local storage so it persists on a refresh
- Skeleton loaders use angular material variables to ensure they look good on dark and light theme.
![Screenshot 2025-03-23 at 13 34 49](https://github.com/user-attachments/assets/a6d17e51-572f-4635-83d9-0a29a2e6a823)
